### PR TITLE
Fix Android build: remove deprecated setAppCacheEnabled() call

### DIFF
--- a/android/app/src/main/java/com/cleanfinding/browser/MainActivity.kt
+++ b/android/app/src/main/java/com/cleanfinding/browser/MainActivity.kt
@@ -197,7 +197,7 @@ class MainActivity : AppCompatActivity() {
             // Apply cache mode settings
             if (isIncognito) {
                 cacheMode = WebSettings.LOAD_NO_CACHE
-                setAppCacheEnabled(false)
+                // Note: setAppCacheEnabled() was removed from Android API
             } else {
                 cacheMode = when (preferencesManager.getCacheMode()) {
                     "normal" -> WebSettings.LOAD_DEFAULT


### PR DESCRIPTION
The setAppCacheEnabled() method was removed from Android WebView API. Setting cacheMode to LOAD_NO_CACHE is sufficient for disabling cache in incognito mode.

This fixes the compilation error:
Unresolved reference: setAppCacheEnabled