### PR TITLE
Add WebView console logging for easier JavaScript debugging

### DIFF
--- a/android/app/src/main/java/com/cleanfinding/browser/MainActivity.kt
+++ b/android/app/src/main/java/com/cleanfinding/browser/MainActivity.kt
@@ -426,6 +426,14 @@ class MainActivity : AppCompatActivity() {
                 customViewCallback?.onCustomViewHidden()
                 customViewCallback = null
             }
+
+            // Log JavaScript console messages for debugging
+            override fun onConsoleMessage(consoleMessage: android.webkit.ConsoleMessage?): Boolean {
+                consoleMessage?.let {
+                    android.util.Log.d("WebView", "${it.message()} -- From line ${it.lineNumber()} of ${it.sourceId()}")
+                }
+                return super.onConsoleMessage(consoleMessage)
+            }
         }
 
         // Download listener


### PR DESCRIPTION
Added onConsoleMessage override to WebChromeClient to log JavaScript console messages to Android logcat. This will help debug issues like the current search error where the API key is not configured.

Console messages will appear in logcat with tag 'WebView'.