### PR TITLE
Add debug script for WebView console monitoring

### DIFF
--- a/debug-webview.sh
+++ b/debug-webview.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Debug script for CleanFinding Android Browser
+# This will show JavaScript console messages from the WebView
+
+echo "=== CleanFinding Browser Debug ==="
+echo "Starting logcat monitoring..."
+echo "1. Make sure your Android device is connected via USB"
+echo "2. Enable USB debugging on your device"
+echo "3. Open CleanFinding Browser app"
+echo "4. Try a search query"
+echo ""
+echo "JavaScript console messages will appear below:"
+echo "================================================"
+echo ""
+
+adb logcat -c  # Clear old logs
+adb logcat -s WebView:D | grep --line-buffered -E "WebView|Search|error|Error|failed|Failed"


### PR DESCRIPTION
Created debug-webview.sh to help diagnose JavaScript errors in the Android WebView. The script uses adb logcat to monitor WebView console messages in real-time.

Usage:
1. Connect Android device via USB
2. Run ./debug-webview.sh
3. Open CleanFinding Browser and perform actions
4. Console logs will appear in terminal