### PR TITLE
Always enable JavaScript and DOM storage for search functionality

### DIFF
--- a/android/app/src/main/java/com/cleanfinding/browser/MainActivity.kt
+++ b/android/app/src/main/java/com/cleanfinding/browser/MainActivity.kt
@@ -180,10 +180,11 @@ class MainActivity : AppCompatActivity() {
         wv.setLayerType(View.LAYER_TYPE_HARDWARE, null)
 
         wv.settings.apply {
-            // Apply settings from preferences (or defaults for incognito)
-            javaScriptEnabled = if (isIncognito) true else preferencesManager.getJavaScriptEnabled()
-            domStorageEnabled = if (isIncognito) false else preferencesManager.getDomStorageEnabled()
-            databaseEnabled = if (isIncognito) false else preferencesManager.getDomStorageEnabled()
+            // CRITICAL: Always enable JavaScript and DOM storage for search to work
+            // Modern websites (including cleanfinding.com search) require these features
+            javaScriptEnabled = true
+            domStorageEnabled = !isIncognito  // Enable DOM storage unless in incognito mode
+            databaseEnabled = !isIncognito  // Enable database unless in incognito mode
             setSupportZoom(true)
             builtInZoomControls = true
             displayZoomControls = false


### PR DESCRIPTION
Changed WebView settings to always enable JavaScript and DOM storage (except DOM storage in incognito mode for privacy).

Previous behavior: These settings depended on user preferences
New behavior: Always enabled (essential for modern web apps)

This fixes issues where:
- User had disabled JavaScript in settings
- User had disabled DOM storage in settings
- CleanFinding.com search requires both to function

JavaScript is required for:
- Fetch API calls to /api/search
- Dynamic result rendering
- Search functionality

DOM storage is required for:
- Response caching
- Search state management