### PR TITLE
Fix search failure by skipping ad blocking on CleanFinding.com

### DIFF
--- a/android/app/src/main/java/com/cleanfinding/browser/MainActivity.kt
+++ b/android/app/src/main/java/com/cleanfinding/browser/MainActivity.kt
@@ -1065,6 +1065,13 @@ class MainActivity : AppCompatActivity() {
         val escapedDomains = blockedDomains.map { escapeJavaScriptString(it) }
         val script = """
             (function() {
+                // CRITICAL: Skip ad blocking on CleanFinding.com to prevent breaking search functionality
+                // The ad blocking CSS selectors are too broad and can hide legitimate page elements
+                if (window.location.hostname.indexOf('cleanfinding.com') !== -1) {
+                    console.log('CleanFinding: Skipping ad blocking on cleanfinding.com');
+                    return;
+                }
+
                 var blockedDomains = ${escapedDomains.joinToString(",", "[", "]") { "\"$it\"" }};
 
                 var originalXHR = window.XMLHttpRequest;

--- a/ios/CleanFindingBrowser/CleanFindingBrowser/BrowserViewController.swift
+++ b/ios/CleanFindingBrowser/CleanFindingBrowser/BrowserViewController.swift
@@ -257,6 +257,12 @@ class BrowserViewController: UIViewController {
         let domainsJSON = blockedDomains.map { "\"\($0)\"" }.joined(separator: ",")
         return """
         (function() {
+            // CRITICAL: Skip ad blocking on CleanFinding.com to prevent breaking search functionality
+            if (window.location.hostname.indexOf('cleanfinding.com') !== -1) {
+                console.log('CleanFinding: Skipping ad blocking on cleanfinding.com');
+                return;
+            }
+
             var blockedDomains = [\(domainsJSON)];
 
             // Override fetch


### PR DESCRIPTION
ROOT CAUSE: The ad blocking CSS selectors like [class*="ad-"] were too broad and matched legitimate page elements on cleanfinding.com, hiding search functionality.

Fix: Skip the entire ad blocking script when on cleanfinding.com since:
1. CleanFinding.com is a privacy-focused search engine with no ads
2. The broad CSS selectors were breaking the search page
3. Tracker blocking for third-party domains still works normally

Applied to both Android and iOS platforms.