### PR TITLE
Fix YouTube black screen by disabling DuckPlayer by default

### DIFF
--- a/android/app/src/main/java/com/cleanfinding/browser/PreferencesManager.kt
+++ b/android/app/src/main/java/com/cleanfinding/browser/PreferencesManager.kt
@@ -47,7 +47,10 @@ class PreferencesManager(context: Context) {
         const val DEFAULT_BLOCK_ADULT_CONTENT = true
         const val DEFAULT_FORCE_HTTPS = true
         const val DEFAULT_FORCE_SAFE_SEARCH = true
-        const val DEFAULT_DUCK_PLAYER = true
+        // CRITICAL FIX: DuckPlayer disabled by default to allow native YouTube playback
+        // When enabled, YouTube redirects to youtube-nocookie.com/embed which causes black screen
+        // Users can enable this manually in settings if they prefer privacy over native playback
+        const val DEFAULT_DUCK_PLAYER = false
         const val DEFAULT_EMAIL_PROTECTION = true
         const val DEFAULT_DARK_MODE = true
         const val DEFAULT_SHOW_IMAGES = true


### PR DESCRIPTION
ROOT CAUSE: DuckPlayer was enabled by default (DEFAULT_DUCK_PLAYER = true), which redirects all YouTube URLs to youtube-nocookie.com/embed/ format. This embed URL causes black screen issues in Android WebView because:
1. YouTube embeds have stricter security restrictions
2. WebView handles embeds differently than native pages
3. The embed doesn't support all video playback features

SOLUTION: Changed DEFAULT_DUCK_PLAYER from true to false.
- YouTube now loads natively like Chrome browser does
- Users can still enable DuckPlayer manually in Settings for privacy
- Native YouTube playback works with proper Chrome Mobile user agent

Research sources:
- YouTube detects WebView by "wv" token in user agent
- Chrome Mobile UA doesn't have WebView identifiers
- Native YouTube site works better than embed in WebView