### PR TITLE
Fix YouTube video black screen by skipping script injections

### DIFF
--- a/android/app/src/main/java/com/cleanfinding/browser/MainActivity.kt
+++ b/android/app/src/main/java/com/cleanfinding/browser/MainActivity.kt
@@ -1270,6 +1270,15 @@ class MainActivity : AppCompatActivity() {
                     return;
                 }
 
+                // CRITICAL: Skip ad blocking on YouTube to prevent video playback issues
+                // YouTube's internal classes contain "ad" patterns that our selectors would incorrectly match
+                // YouTube handles its own ad blocking detection and breaks if we interfere
+                if (window.location.hostname.indexOf('youtube.com') !== -1 ||
+                    window.location.hostname.indexOf('youtu.be') !== -1) {
+                    console.log('CleanFinding: Skipping ad blocking on YouTube for proper video playback');
+                    return;
+                }
+
                 var blockedDomains = ${escapedDomains.joinToString(",", "[", "]") { "\"$it\"" }};
 
                 var originalXHR = window.XMLHttpRequest;
@@ -1426,11 +1435,21 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun injectVideoFixCSS(view: WebView?) {
-        // CRITICAL FIX: Enhanced video and image rendering fixes for Pinterest and YouTube
+        // CRITICAL FIX: Enhanced video and image rendering fixes for Pinterest
+        // NOTE: We skip YouTube because our CSS overrides interfere with YouTube's native player
         val cssScript = """
             (function() {
+                // CRITICAL: Skip CSS injection on YouTube - their player is complex and our
+                // overrides with !important break the native video rendering
+                // YouTube works best when left completely alone
+                var hostname = window.location.hostname;
+                if (hostname.indexOf('youtube.com') !== -1 || hostname.indexOf('youtu.be') !== -1) {
+                    console.log('CleanFinding: Skipping media fixes on YouTube - using native player');
+                    return;
+                }
+
                 if (document.getElementById('cleanfinding-media-fix')) return;
-                console.log('CleanFinding: Applying Pinterest/YouTube media fixes...');
+                console.log('CleanFinding: Applying Pinterest media fixes...');
 
                 // Inject comprehensive CSS fixes
                 var style = document.createElement('style');

--- a/android/app/src/main/java/com/cleanfinding/browser/PreferencesManager.kt
+++ b/android/app/src/main/java/com/cleanfinding/browser/PreferencesManager.kt
@@ -12,7 +12,32 @@ class PreferencesManager(context: Context) {
 
     private val prefs: SharedPreferences = PreferenceManager.getDefaultSharedPreferences(context)
 
+    init {
+        // Run preference migrations on initialization
+        runMigrations()
+    }
+
+    /**
+     * Run preference migrations to fix issues for existing users
+     */
+    private fun runMigrations() {
+        val currentVersion = prefs.getInt(KEY_PREFS_VERSION, 0)
+
+        // Migration v1: Disable DuckPlayer for all existing users
+        // DuckPlayer causes YouTube black screen by redirecting to youtube-nocookie.com/embed
+        // Users who installed before this fix would have the old default (true) saved
+        if (currentVersion < 1) {
+            // Force DuckPlayer off for all existing installations
+            prefs.edit()
+                .putBoolean(KEY_DUCK_PLAYER, false)
+                .putInt(KEY_PREFS_VERSION, 1)
+                .apply()
+        }
+    }
+
     companion object {
+        // Preference version for migrations
+        const val KEY_PREFS_VERSION = "prefs_version"
         // Privacy settings
         const val KEY_BLOCK_TRACKERS = "block_trackers"
         const val KEY_BLOCK_ADS = "block_ads"


### PR DESCRIPTION
Root cause: Our ad blocking CSS selectors ([class*="ad-"]) and video fix CSS with !important rules were interfering with YouTube's native player. Additionally, existing users still had DuckPlayer enabled from before the previous fix.

Changes:
- Skip ad blocking script injection on youtube.com/youtu.be
- Skip video fix CSS injection on YouTube (let native player work)
- Add preference migration to force DuckPlayer off for existing users