### PR TITLE
Fix voice search and screenshot bugs across Android and iOS

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -5,6 +5,9 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.DOWNLOAD_WITHOUT_NOTIFICATION" />
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28" />
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
 
     <application
         android:allowBackup="true"
@@ -60,6 +63,16 @@
             android:exported="false"
             android:parentActivityName=".MainActivity"
             android:theme="@style/Theme.CleanFindingBrowser" />
+
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
 
     </application>
 

--- a/android/app/src/main/res/xml/file_paths.xml
+++ b/android/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <external-path name="pictures" path="Pictures/CleanFinding/" />
+    <cache-path name="cache" path="screenshots/" />
+</paths>

--- a/ios/CleanFindingBrowser/CleanFindingBrowser/Info.plist
+++ b/ios/CleanFindingBrowser/CleanFindingBrowser/Info.plist
@@ -65,5 +65,11 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSSpeechRecognitionUsageDescription</key>
+	<string>CleanFinding Browser uses speech recognition for voice search.</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>CleanFinding Browser needs microphone access for voice search.</string>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>CleanFinding Browser saves screenshots to your photo library.</string>
 </dict>
 </plist>


### PR DESCRIPTION
- Fix Android voice search calling non-existent navigateToUrl() - changed to loadUrl()
- Add required permissions for voice search and screenshots:
  - Android: RECORD_AUDIO, WRITE_EXTERNAL_STORAGE (legacy), READ_MEDIA_IMAGES
  - iOS: NSSpeechRecognitionUsageDescription, NSMicrophoneUsageDescription, NSPhotoLibraryAddUsageDescription
- Update Android screenshot to use MediaStore API for Android 10+ (scoped storage)
- Add FileProvider configuration for screenshot sharing on Android
- Create file_paths.xml for FileProvider paths