### PR TITLE
Fix release creation: delete existing release before recreating

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -174,6 +174,19 @@ jobs:
             echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
           fi
 
+      - name: Delete existing release if present
+        run: |
+          TAG="v${{ steps.version.outputs.VERSION }}"
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Deleting existing release $TAG"
+            gh release delete "$TAG" --yes
+          else
+            echo "No existing release $TAG to delete"
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true
+
       - name: Create/Update Release
         uses: softprops/action-gh-release@v1
         with:


### PR DESCRIPTION
The create-release job fails with 422 'already_exists' when a release with the same tag and assets already exists from a previous run. Added a step to delete the existing release (if present) before creating the new one, preventing asset name conflicts.

https://claude.ai/code/session_017LiCXZeqvAquQg4ZvmD2rr