### PR TITLE
Harden desktop privacy handlers and add Android/Desktop feature review

### DIFF
--- a/FEATURE_REVIEW_ANDROID_DESKTOP.md
+++ b/FEATURE_REVIEW_ANDROID_DESKTOP.md
@@ -1,0 +1,34 @@
+# Android + Desktop Feature Review
+
+## Scope Reviewed
+- Android browser implementation in `android/app/src/main/java/com/cleanfinding/browser/MainActivity.kt`
+- Desktop Electron main process in `desktop/main.js`
+- Existing release and testing documents in repository root
+
+## High-Level Assessment
+All core features appear to be present and integrated well: tab management, privacy controls, tracker blocking, Duck Player support, downloads/history, and settings flows.
+
+## What is Working Well
+1. **Feature completeness**: both Android and Desktop have broad privacy and browsing coverage.
+2. **Security direction**: URL-scheme validation and secure defaults are already in place.
+3. **Architecture**: privacy handlers and manager classes keep concerns separated.
+4. **User-focused capabilities**: gestures, reader mode, PiP, voice search, and dashboards improve daily usability.
+
+## Improvements Recommended
+1. **Desktop webRequest listener lifecycle (implemented)**  
+   `setupPrivacyFeatures()` is called after setting changes and re-registers request handlers. Resetting handlers before re-registering avoids stale/duplicated behavior, especially for `onCompleted` and `onBeforeSendHeaders`.
+
+2. **Desktop Duck Player script injection scope (implemented)**  
+   Injection should only run on `mainFrame` completions and only when `mainWindow` is alive. This reduces unnecessary script execution and prevents potential runtime errors after window teardown.
+
+3. **Add automated regression checks for privacy toggles (recommended next)**  
+   A focused test that flips each privacy setting and verifies request behavior would prevent future regressions.
+
+4. **Consolidate tracker-domain strategy across platforms (recommended next)**  
+   Android and Desktop maintain separate tracker domain lists. A shared canonical list/process would improve consistency and maintenance.
+
+5. **Telemetry for blocked events (recommended next)**  
+   Optional, privacy-safe local counters per session/platform can improve observability of real feature effectiveness.
+
+## Conclusion
+The feature set is in good shape and appears production-oriented. The most immediate technical hardening on Desktop request-handler lifecycle has now been addressed.


### PR DESCRIPTION
### Motivation
- Prevent stale or duplicated Electron `webRequest` handlers when privacy settings change by resetting listeners before re-registering them. 
- Reduce runtime errors from injecting Duck Player script after the main window is torn down by scoping injection to the main frame and ensuring the window is alive. 
- Capture a cross-platform review of Android and Desktop features and surface recommended follow-ups for consistency and testing.

### Description
- Reset `session.defaultSession.webRequest` handlers at the start of `setupPrivacyFeatures()` by calling `onBeforeRequest(null)`, `onCompleted(null)`, and `onBeforeSendHeaders(null)` to clear previously-registered callbacks. 
- Tighten Duck Player injection in `ses.webRequest.onCompleted(...)` to only run when `details.resourceType === 'mainFrame'` and `mainWindow` exists and `!mainWindow.isDestroyed()`. 
- Leave the existing `onBeforeRequest` logic for Duck Player redirects and tracker blocking intact while ensuring handlers are re-registered cleanly. 
- Add `FEATURE_REVIEW_ANDROID_DESKTOP.md` documenting the feature review, what is working well, implemented fixes, and recommended next steps (tests, consolidation of tracker lists, telemetry suggestions).

### Testing
- Performed a syntax check with `node --check desktop/main.js`, which completed successfully. 
- No additional automated unit tests were present or modified in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998975825788332b1bb97da0c07088e)