### PR TITLE
Implement retry flow for failed/cancelled downloads

### DIFF
--- a/android/app/src/main/java/com/cleanfinding/browser/DownloadsActivity.kt
+++ b/android/app/src/main/java/com/cleanfinding/browser/DownloadsActivity.kt
@@ -75,14 +75,14 @@ class DownloadsActivity : AppCompatActivity() {
                 Toast.makeText(this, "Download cancelled", Toast.LENGTH_SHORT).show()
             },
             onRetryClick = { download ->
-                // Retry download
-                Toast.makeText(
-                    this,
-                    "Retry not implemented yet. Please download again.",
-                    Toast.LENGTH_SHORT
-                ).show()
-                // TODO: Implement retry logic
-                // downloadManager.startDownload(download.url, download.filename, download.mimeType)
+                downloadManager.retryDownload(download) { success, errorMessage ->
+                    val message = if (success) {
+                        "Download restarted"
+                    } else {
+                        "Retry failed${errorMessage?.let { ": $it" } ?: ""}"
+                    }
+                    Toast.makeText(this, message, Toast.LENGTH_SHORT).show()
+                }
             }
         )
 


### PR DESCRIPTION
### Motivation
- Provide a working retry path for downloads previously marked `FAILED`/`CANCELLED` to address the existing `TODO` and improve the downloads UX. 
- Ensure retries produce a clean new download record and remove stale DownloadManager entries so progress and status reflect a fresh attempt.

### Description
- Added `retryDownload(download: Download, onComplete: ((Boolean, String?) -> Unit)? = null)` to `DownloadManagerHelper` which validates the URL, removes any existing system download job, deletes the old DB record, and enqueues a fresh download via `startDownload`.
- Wired the downloads UI to call the new API from `DownloadsActivity` and replaced the placeholder retry toast with callback-driven success/failure feedback to the user.
- Modified files: `android/app/src/main/java/com/cleanfinding/browser/DownloadManagerHelper.kt` and `android/app/src/main/java/com/cleanfinding/browser/DownloadsActivity.kt`.

### Testing
- Attempted to compile Kotlin with `./gradlew :app:compileDebugKotlin`, which failed in this environment due to a Gradle/JDK class-version mismatch (`Unsupported class file major version 69`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998a46705808332bea9419a0b7b4675)