### PR TITLE
Harden download retry and restore DownloadsActivity cleanup

### DIFF
--- a/android/app/src/main/java/com/cleanfinding/browser/DownloadsActivity.kt
+++ b/android/app/src/main/java/com/cleanfinding/browser/DownloadsActivity.kt
@@ -75,14 +75,14 @@ class DownloadsActivity : AppCompatActivity() {
                 Toast.makeText(this, "Download cancelled", Toast.LENGTH_SHORT).show()
             },
             onRetryClick = { download ->
-                // Retry download
-                Toast.makeText(
-                    this,
-                    "Retry not implemented yet. Please download again.",
-                    Toast.LENGTH_SHORT
-                ).show()
-                // TODO: Implement retry logic
-                // downloadManager.startDownload(download.url, download.filename, download.mimeType)
+                downloadManager.retryDownload(download) { success, errorMessage ->
+                    val message = if (success) {
+                        "Download restarted"
+                    } else {
+                        "Retry failed${errorMessage?.let { ": $it" } ?: ""}"
+                    }
+                    Toast.makeText(this, message, Toast.LENGTH_SHORT).show()
+                }
             }
         )
 
@@ -195,7 +195,7 @@ class DownloadsActivity : AppCompatActivity() {
 
     override fun onDestroy() {
         super.onDestroy()
-        // Don't cleanup downloadManager here as it might be used elsewhere
-        // downloadManager.cleanup()
+        // Release receiver and coroutine scope owned by this Activity.
+        downloadManager.cleanup()
     }
 }

--- a/android/app/src/main/java/com/cleanfinding/browser/SettingsActivity.kt
+++ b/android/app/src/main/java/com/cleanfinding/browser/SettingsActivity.kt
@@ -108,14 +108,14 @@ class SettingsActivity : AppCompatActivity() {
 
             // Clear history
             val historyManager = HistoryManager(context)
-            historyManager.clearAllHistory { count ->
-                // History cleared
+            historyManager.clearAllHistory {
+                historyManager.cleanup()
             }
 
             // Clear downloads
             val downloadManager = DownloadManagerHelper(context)
-            downloadManager.clearAllDownloads { count ->
-                // Downloads cleared
+            downloadManager.clearAllDownloads {
+                downloadManager.cleanup()
             }
 
             // Clear cookies


### PR DESCRIPTION
### Motivation
- Provide a safe retry path for downloads previously marked `FAILED`/`CANCELLED` to avoid losing download records and improve UX.
- Ensure `DownloadsActivity` releases the `DownloadManagerHelper` receiver/coroutine scope on `onDestroy()` to prevent leaks.

### Description
- Added a hardened `retryDownload(download: Download, onComplete: ((Boolean, String?) -> Unit)? = null)` in `DownloadManagerHelper` that checks `download.canRetry()`, validates the URL, enqueues a fresh download via `startDownload`, and then removes the stale system job and old DB row.
- Wired the downloads UI to call `downloadManager.retryDownload(...)` and report success/failure via `Toast` messages.
- Restored `downloadManager.cleanup()` in `DownloadsActivity.onDestroy()` to properly release the receiver and coroutine scope.

### Testing
- Ran `rg -n "TODO: Implement retry logic|Retry not implemented yet" android/app/src/main/java/com/cleanfinding/browser` and confirmed there are no remaining placeholder retry TODOs.
- Attempted `./gradlew :app:compileDebugKotlin` which failed in this environment due to a Gradle/JDK class-version mismatch (`Unsupported class file major version 69`), so a full build could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998a46705808332bea9419a0b7b4675)