### PR TITLE
docs: add CONTRIBUTING, CHANGELOG, and iOS build guide; update README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Added
+- Added `CONTRIBUTING.md` with contributor workflow, build, and PR guidance.
+- Added `ios/README.md` with iOS development and archive instructions.
+
+## [1.0.1] - 2026-01-10
+### Fixed
+- Video playback rendering issues in Android WebView.
+- Image clipping and overflow rendering issues on media-heavy pages.
+- Hardware acceleration and layout handling improvements for better compatibility.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,63 @@
+# Contributing to CleanFinding Browser
+
+Thanks for your interest in contributing to CleanFinding Browser.
+
+## Development setup
+
+### Prerequisites
+- Git
+- Java 17 (for Android builds)
+- Android Studio (latest stable)
+- Node.js 18+ (for desktop tooling)
+- Xcode 15+ on macOS (for iOS builds)
+
+### Clone and branch
+```bash
+git clone <your-fork-url>
+cd cleanfinding-browser
+git checkout -b feature/short-description
+```
+
+## Project structure
+- `android/` Android app source
+- `ios/` iOS app source
+- `desktop/` Electron desktop app source
+- `.github/workflows/` CI workflows
+
+## Build and test
+
+### Android
+```bash
+cd android
+./gradlew assembleDebug
+./gradlew test
+```
+
+### Desktop
+```bash
+cd desktop
+npm install
+npm run lint
+```
+
+### iOS
+See [ios/README.md](ios/README.md) for detailed local build instructions.
+
+## Commit guidelines
+- Use clear commit messages (e.g., `fix(android): prevent tab crash on rotation`).
+- Keep commits focused and small.
+- Update documentation when behavior changes.
+
+## Pull request checklist
+- [ ] Code builds locally for the target platform
+- [ ] Tests or checks relevant to the change pass
+- [ ] Documentation updated (if needed)
+- [ ] No secrets or generated artifacts added
+
+## Reporting issues
+When filing issues, include:
+- Platform (Android / iOS / Desktop)
+- App version
+- Steps to reproduce
+- Expected vs. actual behavior
+- Screenshots/logs if available

--- a/README.md
+++ b/README.md
@@ -59,7 +59,9 @@ cd android
 - Apple Developer Account
 
 ### Build
-Open `ios/CleanFindingBrowser.xcodeproj` in Xcode and build.
+Open `ios/CleanFindingBrowser/CleanFindingBrowser.xcodeproj` in Xcode and build.
+
+For full setup, signing, simulator, and archive steps, see [ios/README.md](ios/README.md).
 
 ## Download
 

--- a/ios/README.md
+++ b/ios/README.md
@@ -1,0 +1,40 @@
+# CleanFinding Browser iOS Build Guide
+
+This document explains how to build, run, and archive the iOS app.
+
+## Requirements
+- macOS 13+
+- Xcode 15+
+- Apple Developer account (for device install/TestFlight/App Store)
+
+## Open the project
+1. Open Xcode.
+2. Select **File → Open...**.
+3. Choose `ios/CleanFindingBrowser/CleanFindingBrowser.xcodeproj`.
+
+## Configure signing
+1. Select the **CleanFindingBrowser** project in the navigator.
+2. Select the **CleanFindingBrowser** target.
+3. Open **Signing & Capabilities**.
+4. Choose your Team.
+5. Ensure the Bundle Identifier is unique for local testing if needed.
+
+## Run on Simulator
+1. Choose an iPhone simulator (for example, iPhone 15).
+2. Press **⌘R** to build and run.
+
+## Run on physical device
+1. Connect your device and trust the development certificate.
+2. Select your device in Xcode.
+3. Press **⌘R**.
+
+## Create a release archive
+1. Select **Any iOS Device (arm64)** in destination.
+2. Choose **Product → Archive**.
+3. In Organizer, select the archive and click **Distribute App**.
+4. Choose TestFlight or App Store Connect and follow prompts.
+
+## Troubleshooting
+- **Signing failed**: Re-check Team and provisioning profile settings.
+- **Bundle identifier conflict**: Change Bundle ID for local testing.
+- **Build errors after Xcode update**: Clean build folder (**Shift+⌘K**) and rebuild.


### PR DESCRIPTION
### Motivation
- Provide contributor onboarding and build/test guidance to reduce friction for new contributors and clarify project structure.
- Establish a recorded changelog with an `Unreleased` section so future changes are tracked consistently.
- Supply a dedicated iOS build guide that documents Xcode project location, signing, simulator/device run, and archive steps.
- Correct the README iOS project path and link to the new detailed iOS guide for clearer developer workflows.

### Description
- Added `CONTRIBUTING.md` with prerequisites, clone/branch instructions, build/test commands, commit guidance, and a PR checklist.
- Added `CHANGELOG.md` with an `Unreleased` section and the recorded `1.0.1` fixes summary.
- Added `ios/README.md` containing step-by-step Xcode open, signing, simulator/device run, archive, and troubleshooting instructions.
- Updated `README.md` to fix the Xcode project path to `ios/CleanFindingBrowser/CleanFindingBrowser.xcodeproj` and link to `ios/README.md`.

### Testing
- Ran `git diff --check HEAD~1 HEAD` to validate there are no diff/whitespace issues and it completed without errors.
- Ran `git status --short` to confirm the working tree shows only the expected staged files and existing untracked directories and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69995b8659848332a73b8aa8fe8a78b3)